### PR TITLE
Do not use trailing slash for delete operations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ version of the scene.
 ## DELETE a user scene
 
 DELETE request (also with the user `Authorization` header) to
-`https://cloud.shapespark.com/scenes/SCENE_NAME/` deletes a scene
+`https://cloud.shapespark.com/scenes/SCENE_NAME` deletes a scene
 created by the user.
 
 # The API for managing users.


### PR DESCRIPTION
For consistency with the DELETE /users/USERNAME request the DELETE /users/USERNAME/scenes/SCENE_NAME request now do not use the trailing slash either.

The old variant with the slash is still handled by the server for existing clients.